### PR TITLE
fix: add missing stub and use insert/delete permission on update column permission check

### DIFF
--- a/plugin-trino/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
+++ b/plugin-trino/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
@@ -676,9 +676,19 @@ public class RangerSystemAccessControl
     }
   }
 
+  /**
+   * This is evaluated on table column level
+   */
   @Override
   public void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Set<String> updatedColumnNames) {
-    SystemAccessControl.super.checkCanUpdateTableColumns(securityContext, table, updatedColumnNames);
+    // SystemAccessControl.super.checkCanUpdateTableColumns(securityContext, table, updatedColumnNames); // ALWAYS DENY
+    try {
+      // USE INSERT AND DELETE PERMISSIONS INSTEAD
+      checkCanInsertIntoTable(securityContext, table);
+      checkCanDeleteFromTable(securityContext, table);
+    } catch (AccessDeniedException ade) {
+      AccessDeniedException.denyUpdateTableColumns(table.toString(), updatedColumnNames);
+    }
   }
 
   /** FUNCTIONS **/

--- a/ranger-trino-plugin-shim/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
+++ b/ranger-trino-plugin-shim/src/main/java/org/apache/ranger/authorization/trino/authorizer/RangerSystemAccessControl.java
@@ -397,6 +397,26 @@ public class RangerSystemAccessControl
   }
 
   @Override
+  public void checkCanUpdateTableColumns(SystemSecurityContext securityContext, CatalogSchemaTableName table, Set<String> updatedColumnNames) {
+    try {
+      activatePluginClassLoader();
+      systemAccessControlImpl.checkCanUpdateTableColumns(securityContext, table, updatedColumnNames);
+    } finally {
+      deactivatePluginClassLoader();
+    }
+  }
+
+  @Override
+  public void checkCanAlterColumn(SystemSecurityContext context, CatalogSchemaTableName table) {
+    try {
+      activatePluginClassLoader();
+      systemAccessControlImpl.checkCanAlterColumn(context, table);
+    } finally {
+      deactivatePluginClassLoader();
+    }
+  }
+
+  @Override
   public void checkCanShowCreateTable(SystemSecurityContext context, CatalogSchemaTableName table) {
     try {
       activatePluginClassLoader();


### PR DESCRIPTION
- https://github.com/aakashnand/ranger/commit/a19fe10bd301b0317b895008a63b6706b280ff8e#r140649823

I noticed this method is unimplemented today due not to perform MERGE INTO query on Iceberg format table with our Trino.

As you know, checkCanUpdateTableColumns() method of SPI base class ALWAYS deny the request.

How about using INSERT & DELETE permission check?

plus, I guess the stub of those missing methods have to be implemented also on the shim codes!